### PR TITLE
Rake task refresh conditions

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,16 @@
+require_relative '../../db/spot_scrape'
+
+namespace :db do
+  desc "Refresh conditions for each spot in database"
+  task refresh_conditions: :environment do
+    # puts "is this thing on?"
+    @spots = Spot.all
+
+    @spots.each do |spot|
+      puts "updating #{spot.name}'s conditions"
+      create_condition(spot, spot.surfline_spot)
+    end
+
+    puts 'Conditions refreshed'
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -6,6 +6,10 @@ namespace :db do
     # puts "is this thing on?"
     @spots = Spot.all
 
+    puts 'Cleaning out old conditions..'
+    Condition.destroy_all
+
+    puts 'Refreshing conditions..'
     @spots.each do |spot|
       puts "updating #{spot.name}'s conditions"
       create_condition(spot, spot.surfline_spot)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80548486/120225500-5ddf1400-c213-11eb-8d8d-6d7086428826.png)

Rake task clears old conditions for each spot, reruns #create_condition method from spot_scrape.rb to create new conditions at current point in time. 

namespace 'rails db:refresh_conditions'