### PR TITLE
Changed the dashboard dropdowns color to black

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -79,6 +79,10 @@ h1, h2 {
   align-items: center;
   margin-bottom: 20px;
   // justify-content: space-between;
+
+  select option {
+    color: black;
+  }
 }
 
 #preference {

--- a/app/views/shared/_middle_dropdowns-buttons.html.erb
+++ b/app/views/shared/_middle_dropdowns-buttons.html.erb
@@ -1,6 +1,6 @@
 <% if @user_spots.present? %>
     <%= simple_form_for :result, url: result_spot_path(:all_waves), remote: true, html: { 'data-controller': 'dashboard', class: 'preference-spot-block'}, method: :get do |f| %>
-      <%= f.input :preference_id, collection: current_user.grouped_preferences, include_blank: false, input_html: { 'data-action': 'change->dashboard#handleSelect', id: 'preference'}, label: false %>
+        <%= f.input :preference_id, collection: current_user.grouped_preferences, include_blank: false, input_html: { 'data-action': 'change->dashboard#handleSelect', id: 'preference' }, label: false %>
       <%= link_to "My preferences", preferences_path, class: "body-btn light-btn" %>
 
       <%= f.input :spot_id, collection: current_user.spots, include_blank: false, input_html: { 'data-action': 'change->dashboard#handleSelect', id: 'spot'}, label: false %>


### PR DESCRIPTION
The dropdown options where displayed as white on white background, changed to black on white background.
It is not possible to style the options more than the text color since they are OS dependent. (Mac, Windows, etc..)